### PR TITLE
fix(git-lfs):

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.onnx filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Hi!

I'm Peter from Imperial, nice to meet you both! 

I am using your dataset for Proteus, the implementation of the adlet project in MLIR. I was having trouble adding `bennu` as an external dependency and downloading the ONNX models with Git LFS. Apparently the issue was with the `.gitattributes` file not existing in the repo. Thought I would add it, now if someone wants to use your dataset they can add it as a submodule in their project, and download the ONNX models with Git LFS.

The work around I was using was planting the `.gitattributes` file straight into the `bennu` repo after initialization.

```bash
git submodule update --init -- external/bennu
@command -v git-lfs >/dev/null 2>&1 || { echo "Error: git-lfs is required to fetch models." >&2; exit 1; }
# Right here is the workaround, planting the `.gitattributes` file into the repo
printf '*.onnx filter=lfs diff=lfs merge=lfs -text\n' > external/bennu/.gitattributes
git -C external/bennu lfs pull
```

Hope this helps! Have a good one!